### PR TITLE
feat: 환율 조회 API 연동 및 UI 반영 / #55

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -45,6 +45,7 @@
                 "@testing-library/jest-dom": "^6.9.1",
                 "@testing-library/react": "^16.3.0",
                 "@testing-library/user-event": "^14.6.1",
+                "baseline-browser-mapping": "^2.8.32",
                 "eslint": "^9.39.1",
                 "eslint-config-next": "^16.0.1",
                 "jest": "^30.2.0",
@@ -6823,9 +6824,9 @@
             "license": "MIT"
         },
         "node_modules/baseline-browser-mapping": {
-            "version": "2.8.24",
-            "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.8.24.tgz",
-            "integrity": "sha512-uUhTRDPXamakPyghwrUcjaGvvBqGrWvBHReoiULMIpOJVM9IYzQh83Xk2Onx5HlGI2o10NNCzcs9TG/S3TkwrQ==",
+            "version": "2.8.32",
+            "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.8.32.tgz",
+            "integrity": "sha512-OPz5aBThlyLFgxyhdwf/s2+8ab3OvT7AdTNvKHBwpXomIYeXqpUUuT8LrdtxZSsWJ4R4CU1un4XGh5Ez3nlTpw==",
             "license": "Apache-2.0",
             "bin": {
                 "baseline-browser-mapping": "dist/cli.js"

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.0",
         "@testing-library/user-event": "^14.6.1",
+        "baseline-browser-mapping": "^2.8.32",
         "eslint": "^9.39.1",
         "eslint-config-next": "^16.0.1",
         "jest": "^30.2.0",

--- a/src/app/[locale]/send/components/CardCarousel.jsx
+++ b/src/app/[locale]/send/components/CardCarousel.jsx
@@ -58,7 +58,7 @@ export default function CardCarousel() {
       router.push("/");
       return;
     }
-    router.push("/send/choose");
+    router.push("/send/regular/choose");
   };
 
   return (

--- a/src/app/[locale]/send/regular/choose/page.jsx
+++ b/src/app/[locale]/send/regular/choose/page.jsx
@@ -28,7 +28,7 @@ export default function ChooseCountryPage() {
       dispatch(setReceivedCurrency(currency));
       dispatch(setCountryData(localSelectedCountry)); // Redux 액션 호출
     }
-    router.push("/send/information/type");
+    router.push("/send/regular/information/type");
   };
 
   return (

--- a/src/app/[locale]/send/regular/information/type/page.jsx
+++ b/src/app/[locale]/send/regular/information/type/page.jsx
@@ -32,7 +32,7 @@ const currency = {
 
 export default function TypePage() {
   const [showKRWAmount, setShowKRWAmount] = useState(false); // 금액 작성 여부
-  const [exchangeRate, setExchangeRate] = useState(0); // 환율이 적용된 금액
+  const [krwAmount, setKrwAmount] = useState(0); // 환율 적용된 원화 금액
 
   const router = useRouter();
   const dispatch = useDispatch();
@@ -76,15 +76,20 @@ export default function TypePage() {
   // 송금 금액(외화) 변경 핸들러 (숫자만 받게 + 3자리 콤마)
   const handleAmountChange = (e) => {
     const { value } = e.target;
-    const rawValue = value.replace(/[^0-9]/g, "");
+    const rawValue = value.replace(/[^0-9]/g, ""); // 숫자만 남기기(문자 제거)
 
     if (rawValue === "") {
       setFormData((prev) => ({ ...prev, sendAmount: "" }));
+      setShowKRWAmount(false);
+      setKrwAmount(0);
       return;
     }
 
-    const formattedValue = new Intl.NumberFormat().format(Number(rawValue));
+    const formattedValue = new Intl.NumberFormat("ko-KR").format(
+      Number(rawValue)
+    ); // 숫자 포맷팅(3자리 콤마)
     setFormData((prev) => ({ ...prev, sendAmount: formattedValue }));
+    setShowKRWAmount(false); // 새로 입력 시작 -> 다시 숨김
   };
 
   // 날짜 변경 핸들러
@@ -137,24 +142,19 @@ export default function TypePage() {
     // 정기 해외 송금 신규 등록 요청바디 저장
     dispatch(setTypeData(submissionData));
 
-    router.push("send/regular/information/remittance");
+    router.push("/send/regular/information/remittance");
   };
 
   useEffect(() => {
-    const handleAmountComplete = async () => {
-      // 외화 거래 금액이 작성되자 않으면 작성 미완료로 인식
-      if (!formData.sendAmount || formData.sendAmount.trim() === "") {
+    const fetchExchange = () => {
+      // 수취 통화 코드가 없거나, 금액이 비어 있으면 아무 것도 하지 않음
+      if (!receiveCurrency || !formData.sendAmount.trim()) {
         setShowKRWAmount(false);
+        setKrwAmount(0);
         return;
       }
 
-      // 작성되고 5초 뒤에 작성 완료로 인식
-      const timer = setTimeout(() => {
-        setShowKRWAmount(true);
-      }, 500);
-
-      // 환율 조회
-      if (showKRWAmount) {
+      const timer = setTimeout(async () => {
         try {
           const accessToken = sessionStorage.getItem("accessToken");
 
@@ -167,22 +167,41 @@ export default function TypePage() {
             }
           );
 
-          const responseData = res.data; // 응답값 데이터(한번 더 들어가야 함)
-          if (responseData.code === 200) {
-            setExchangeRate(responseData.data.exchangeRate);
-            console.log("환율이 적용된 금액: ", exchangeRate);
+          const { code, data } = res.data;
+
+          if (code === 200 && data && data.exchangeRate) {
+            const rate = data.exchangeRate; // 예: 1 USD = 1464.8 KRW
+
+            const raw = formData.sendAmount.replace(/,/g, "");
+            const amount = Number(raw);
+
+            if (!amount) {
+              setShowKRWAmount(false);
+              setKrwAmount(0);
+              return;
+            }
+
+            const krw = amount * rate; // 외화 * 환율 = 원화
+            setKrwAmount(krw);
+            setShowKRWAmount(true); // 환율 보여줌
+            console.log("환율이 적용된 금액(원화): ", krw);
+          } else {
+            setShowKRWAmount(false);
+            setKrwAmount(0);
           }
         } catch (error) {
           console.log("환율 조회 실패", error);
+          setShowKRWAmount(false);
+          setKrwAmount(0);
         }
-      }
+      }, 500); // 0.5초 동안 입력이 없으면 "작성 완료"로 인식
 
-      // 다음 입력이 들어오면 초기화
-      return () => clearTimeout(time);
+      // 다음 입력이 들어오면 타이머 취소 (디바운스)
+      return () => clearTimeout(timer);
     };
 
-    handleAmountComplete();
-  });
+    fetchExchange();
+  }, [formData.sendAmount, receiveCurrency]);
 
   return (
     <main>
@@ -296,7 +315,7 @@ export default function TypePage() {
                 {/* 환율 적용된 금액(원화) */}
                 {showKRWAmount && (
                   <p className="text-sm text-[#334D79] text-left font-semibold">
-                    원화: {exchangeRate} KRW
+                    원화: {new Intl.NumberFormat().format(krwAmount)} KRW
                   </p>
                 )}
               </section>

--- a/src/app/[locale]/send/regular/information/type/page.jsx
+++ b/src/app/[locale]/send/regular/information/type/page.jsx
@@ -7,8 +7,9 @@ import { ChevronDown } from "lucide-react";
 import StepProgressBar from "../../../components/StepProgressbar";
 import DatePicker from "./components/DatePicker";
 import BottomBar from "../../../components/BottomBar";
-import AppHeader from "@/src/common/AppHeader/AppHeader";
 import { setTypeData } from "@/src/store/features/send/sendSlice";
+import AppHeader from "@/src/common/AppHeader/AppHeader";
+import { credittoApi } from "@/src/app/api/axios";
 
 // 요일
 const DAYS = [
@@ -30,6 +31,7 @@ const currency = {
 // const connectedAccounts = ["1002-123-123124", "1002-346-346234"];
 
 export default function TypePage() {
+  const [showKRWAmount, setShowKRWAmount] = useState(false); // 금액 작성 여부
   const router = useRouter();
   const dispatch = useDispatch();
 
@@ -116,6 +118,7 @@ export default function TypePage() {
       scheduledDay = formData.scheduled; // "MONDAY" 등 문자열
     }
 
+    // 제출 데이터 폼
     const submissionData = {
       accountNo: formData.accountNo,
       sendCurrency,
@@ -132,8 +135,50 @@ export default function TypePage() {
     // 정기 해외 송금 신규 등록 요청바디 저장
     dispatch(setTypeData(submissionData));
 
-    router.push("/send/information/remittance");
+    router.push("send/regular/information/remittance");
   };
+
+  useEffect(() => {
+    const handleAmountComplete = async () => {
+      // 외화 거래 금액이 작성되자 않으면 작성 미완료로 인식
+      if (!formData.sendAmount || formData.sendAmount.trim() === "") {
+        setShowKRWAmount(false);
+        return;
+      }
+
+      // 작성되고 5초 뒤에 작성 완료로 인식
+      const timer = setTimeout(() => {
+        setShowKRWAmount(true);
+      }, 500);
+
+      // 환율 조회
+      if (showKRWAmount) {
+        try {
+          const accessToken = sessionStorage.getItem("accessToken");
+
+          const res = await credittoApi.get(
+            `/api/exchange/${receiveCurrency}`,
+            {
+              headers: {
+                Authorization: `Bearer ${accessToken}`,
+              },
+            }
+          );
+
+          if (res.code === 200) {
+            console.log(res.data.message);
+          }
+        } catch (error) {
+          console.log("환율 조회 실패", error);
+        }
+      }
+
+      // 다음 입력이 들어오면 초기화
+      return () => clearTimeout(time);
+    };
+
+    handleAmountComplete();
+  });
 
   return (
     <main>
@@ -229,19 +274,28 @@ export default function TypePage() {
               </div>
 
               {/* 외화 거래 금액 */}
-              <div className="flex flex-col items-start">
-                <label className="block text-[0.875rem] font-semibold text-[#4E5969] mb-[6px]">
-                  외화 거래 금액
-                </label>
-                <input
-                  type="text"
-                  inputMode="numeric"
-                  value={formData.sendAmount}
-                  onChange={handleAmountChange}
-                  placeholder="송금할 금액을 입력하세요"
-                  className="w-full px-4 py-3 bg-[#F7F8FA] border-0 rounded-none appearance-none text-black placeholder:text-[#86909C] focus:outline-none"
-                />
-              </div>
+              <section className="flex flex-col gap-2">
+                <div className="flex flex-col items-start">
+                  <label className="block text-[0.875rem] font-semibold text-[#4E5969] mb-[6px]">
+                    외화 거래 금액
+                  </label>
+                  <input
+                    type="text"
+                    inputMode="numeric"
+                    value={formData.sendAmount}
+                    onChange={handleAmountChange}
+                    placeholder="송금할 금액을 입력하세요"
+                    className="w-full px-4 py-3 bg-[#F7F8FA] border-0 rounded-none appearance-none text-black placeholder:text-[#86909C] focus:outline-none"
+                  />
+                </div>
+
+                {/* 환율 적용된 금액(원화) */}
+                {showKRWAmount && (
+                  <p className="text-sm text-[#334D79] text-left font-semibold">
+                    원화: 1000 KRW
+                  </p>
+                )}
+              </section>
 
               {/* 송금 주기 */}
               <div className="flex flex-col items-start">

--- a/src/app/[locale]/send/regular/information/type/page.jsx
+++ b/src/app/[locale]/send/regular/information/type/page.jsx
@@ -32,6 +32,8 @@ const currency = {
 
 export default function TypePage() {
   const [showKRWAmount, setShowKRWAmount] = useState(false); // 금액 작성 여부
+  const [exchangeRate, setExchangeRate] = useState(0); // 환율이 적용된 금액
+
   const router = useRouter();
   const dispatch = useDispatch();
 
@@ -165,8 +167,10 @@ export default function TypePage() {
             }
           );
 
-          if (res.code === 200) {
-            console.log(res.data.message);
+          const responseData = res.data; // 응답값 데이터(한번 더 들어가야 함)
+          if (responseData.code === 200) {
+            setExchangeRate(responseData.data.exchangeRate);
+            console.log("환율이 적용된 금액: ", exchangeRate);
           }
         } catch (error) {
           console.log("환율 조회 실패", error);
@@ -277,7 +281,7 @@ export default function TypePage() {
               <section className="flex flex-col gap-2">
                 <div className="flex flex-col items-start">
                   <label className="block text-[0.875rem] font-semibold text-[#4E5969] mb-[6px]">
-                    외화 거래 금액
+                    외화 거래 금액({receiveCurrency})
                   </label>
                   <input
                     type="text"
@@ -292,7 +296,7 @@ export default function TypePage() {
                 {/* 환율 적용된 금액(원화) */}
                 {showKRWAmount && (
                   <p className="text-sm text-[#334D79] text-left font-semibold">
-                    원화: 1000 KRW
+                    원화: {exchangeRate} KRW
                   </p>
                 )}
               </section>


### PR DESCRIPTION
## 🗞️ 연관된 이슈

### 🔥 이슈번호
- *Resolved* : #55 

## ✅ 작업 내용
- 외화 거래 금액 입력 후 원화로 환율 적용된 금액을 UI에 반영
- 환율 조회 API 구현 및 연동

### 📸 스크린샷 (선택)

## 체크리스트 ✅
- [X] 코드가 정상적으로 컴파일되나요?
- [X] merge할 브랜치의 위치를 확인했나요?
- [ ] 테스트 코드를 작성하셨나요?

## 기타
