### PR TITLE
fix :  신규가입 후 계좌 개설 계좌없음 오류 해결 / #100

### DIFF
--- a/src/app/[locale]/account/create/success/page.jsx
+++ b/src/app/[locale]/account/create/success/page.jsx
@@ -1,14 +1,22 @@
 "use client";
 
-import React from "react";
+import React, { useEffect } from "react";
 import { DotLottieReact } from "@lottiefiles/dotlottie-react";
 import { useRouter } from "next/navigation";
+import { useDispatch } from "react-redux";
+import { resetAccountStatus } from "@/src/store/features/account/accountSlice";
 import BottomBar from "../../../send/components/BottomBar";
 import { useTranslations } from "next-intl";
 
 export default function AccountSuccessPage() {
   const t = useTranslations("account.success");
   const router = useRouter();
+  const dispatch = useDispatch();
+
+  // 성공 페이지에 진입 시 Redux 상태를 초기화하여 계좌 목록을 다시 불러오도록 함
+  useEffect(() => {
+    dispatch(resetAccountStatus());
+  }, [dispatch]);
   return (
     <main className="h-[100dvh] flex justify-end items-center bg-[#e5e5e5]">
       <div className="w-full max-w-[440px] min-h-[100dvh] mx-auto flex flex-col bg-white">
@@ -34,7 +42,7 @@ export default function AccountSuccessPage() {
           <BottomBar
             label={t("toMain")}
             onClick={() => {
-              router.push("/main");
+              router.push("/account/my_account?refresh=true");
             }}
             isActive={true}
           />

--- a/src/app/[locale]/account/my_account/components/ImportAccount/ImportAccount.jsx
+++ b/src/app/[locale]/account/my_account/components/ImportAccount/ImportAccount.jsx
@@ -1,6 +1,6 @@
 "use client";
 import api, { credittoApi } from "@/src/app/api/axios";
-import { useRouter } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 import React, { useEffect } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { setAccounts } from "@/src/store/features/account/accountSlice";
@@ -13,6 +13,7 @@ export default function ImportAccount() {
   const t = useTranslations("account.myAccount");
   const t2 = useTranslations("account.import");
   const router = useRouter();
+  const searchParams = useSearchParams();
   const dispatch = useDispatch();
   const { accounts, status } = useSelector((state) => state.account);
 
@@ -47,11 +48,42 @@ export default function ImportAccount() {
       }
     };
 
-    // 계좌 정보가 아직 없을 때만 API 호출
-    if (status === "idle") {
+    // 계좌 정보가 아직 없을 때 또는 refresh 파라미터가 있을 때 API 호출
+    const shouldRefresh = searchParams.get("refresh") === "true";
+    if (status === "idle" || shouldRefresh) {
       fetchAccounts();
     }
-  }, [dispatch, status, t2]);
+  }, [dispatch, status, t2, searchParams]);
+
+  // 페이지 포커스 시마다 계좌 목록을 새로고침
+  useEffect(() => {
+    const handleFocus = async () => {
+      try {
+        const accessToken = sessionStorage.getItem("accessToken");
+        if (!accessToken) return;
+
+        const response = await credittoApi.get("/api/accounts/me", {
+          headers: {
+            Authorization: `Bearer ${accessToken}`,
+          },
+        });
+
+        if (response.data && response.data.data) {
+          dispatch(setAccounts(response.data.data));
+          sessionStorage.setItem(
+            "accounts",
+            JSON.stringify(response.data.data)
+          );
+        }
+      } catch (error) {
+        console.error(t2("fetchFail"), error);
+      }
+    };
+
+    // 브라우저 탭이 다시 포커스될 때 계좌 목록 갱신
+    window.addEventListener("focus", handleFocus);
+    return () => window.removeEventListener("focus", handleFocus);
+  }, [dispatch, t2]);
   const handleAccount = () => {
     // 비밀번호 확인을 요청하고, 성공 시 '/account/create'로 이동하도록 설정
     dispatch(requireVerification("/account/create"));

--- a/src/store/features/account/accountSlice.js
+++ b/src/store/features/account/accountSlice.js
@@ -50,6 +50,11 @@ export const accountSlice = createSlice({
       state.accountType = null;
       state.password = null;
     },
+
+    // 계좌 목록 상태를 초기화하여 다시 불러오도록 함
+    resetAccountStatus: (state) => {
+      state.status = "idle";
+    },
   },
 });
 
@@ -58,6 +63,7 @@ export const {
   setAccountsBalance,
   setCreateAccount,
   clearCreateAccount,
+  resetAccountStatus,
 } = accountSlice.actions;
 
 export default accountSlice.reducer;


### PR DESCRIPTION
## 🗞️ 연관된 이슈

### 🔥 이슈번호
- *Resolved* : #100

## ✅ 작업 내용

- 이번 PR에서 작업한 내용을 간략히 설명
신규가입 후 계좌 개설 계좌없음 오류 해결 했습니다
새로 고침 안해도 불러옴
1. 계좌 생성 완료 → 성공 페이지
2. "메인으로" 클릭 → `/account/my_account?refresh=true`로 이동
3. ImportAccount가 `refresh=true` 감지 → 즉시 계좌 목록 API 호출
4. 또한 브라우저 포커스 복귀 시에도 자동 업데이트
### 📸 스크린샷 (선택)

## 체크리스트 ✅
- [ ] 코드가 정상적으로 컴파일되나요?
- [ ] merge할 브랜치의 위치를 확인했나요?
- [ ] 테스트 코드를 작성하셨나요?

## 기타
