### PR TITLE
feat : 약관 동의 페이지 라우팅 구조 개선 / #99

### DIFF
--- a/src/app/[locale]/credit/consent/[id]/page.jsx
+++ b/src/app/[locale]/credit/consent/[id]/page.jsx
@@ -82,7 +82,7 @@ export default function ConsentDetailPage() {
         );
       } else {
         // 마지막 동의서까지 완료 → 동의 리스트 페이지로 이동
-        router.push("/credit/consent");
+        router.replace("/credit/consent");
       }
     } else {
       // 이전 페이지로 돌아가기
@@ -138,7 +138,7 @@ export default function ConsentDetailPage() {
               const isBulk = searchParams.get("bulk") === "1";
               if (isBulk) {
                 // bulk 모드에서는 리스트로 보내는 편이 UX 좋음
-                router.push("/credit/consent");
+                router.replace("/credit/consent");
               } else {
                 router.back();
               }
@@ -161,11 +161,11 @@ export default function ConsentDetailPage() {
 
         {/* 스크롤 바 */}
         {!scrolledToBottom && (
-          <div className="pointer-events-none absolute bottom-24 left-0 right-0 h-20 bg-gradient-to-t from-card to-transparent" />
+          <div className="pointer-events-none absolute bottom-24 left-0 right-0 h-20 bg-gradient-to-t from-white to-transparent" />
         )}
 
         {/* 고정 하단 버튼 */}
-        <div className="sticky bottom-0 bg-[card] px-6 py-4">
+        <div className="sticky bottom-0 bg-white px-6 py-4">
           <Button
             onClick={handleAgree}
             className="w-full rounded-xl py-6 text-base font-semibold bg-[#1A3668]"

--- a/src/app/[locale]/credit/consent/[id]/page.jsx
+++ b/src/app/[locale]/credit/consent/[id]/page.jsx
@@ -10,7 +10,7 @@ import { useDispatch } from "react-redux";
 
 export default function ConsentDetailPage() {
   const { id } = useParams(); // 동의서 ID (string)
-  const searchParams = useSearchParams();
+  const searchParam = useSearchParams();
   const router = useRouter();
   const dispatch = useDispatch();
 
@@ -24,31 +24,6 @@ export default function ConsentDetailPage() {
 
   const [scrolledToBottom, setScrolledToBottom] = useState(false);
   const [status, setStatus] = useState("");
-
-  const agreeConsent = async () => {
-    try {
-      const accessToken = sessionStorage.getItem("accessToken");
-
-      const res = await credittoApi.post("/api/consents/agree", {
-        params: {
-          consentCode: term.consentcode,
-        },
-        headers: {
-          Authorization: `Bearer ${accessToken}`,
-        },
-      });
-
-      const { code, message, data } = res.data;
-      if (code === 201 && data.consentStatus === "AGREE") {
-        console.log(message);
-        setStatus(data.consentStatus); // 동의서 상태를 "AGREE"로 업데이트
-
-        return true;
-      }
-    } catch (error) {
-      console.error("특정 동의서 실패: ", error);
-    }
-  };
 
   const handleScroll = (e) => {
     const target = e.currentTarget;
@@ -65,9 +40,9 @@ export default function ConsentDetailPage() {
     dispatch(setConsentChecked({ id: currentId, checked: true }));
 
     // bulk 모드인지 확인
-    const isBulk = searchParams.get("bulk") === "1";
-    const idsParam = searchParams.get("ids");
-    const idxParam = searchParams.get("idx");
+    const isBulk = searchParam.get("bulk") === "1";
+    const idsParam = searchParam.get("ids");
+    const idxParam = searchParam.get("idx");
 
     if (isBulk && idsParam) {
       const ids = idsParam.split(",").filter(Boolean);
@@ -135,7 +110,7 @@ export default function ConsentDetailPage() {
           {/* 닫기 버튼 */}
           <button
             onClick={() => {
-              const isBulk = searchParams.get("bulk") === "1";
+              const isBulk = searchParam.get("bulk") === "1";
               if (isBulk) {
                 // bulk 모드에서는 리스트로 보내는 편이 UX 좋음
                 router.replace("/credit/consent");

--- a/src/app/[locale]/credit/consent/components/ConsentAgree.jsx
+++ b/src/app/[locale]/credit/consent/components/ConsentAgree.jsx
@@ -10,6 +10,7 @@ export default function ConsentAgree({
   title = "약관 동의",
   consents = [], // 약관 동의서 리스트
   nextPath,
+  onBackClick,
 }) {
   const router = useRouter();
   const dispatch = useDispatch();
@@ -53,7 +54,7 @@ export default function ConsentAgree({
     const idsParam = ids.join(",");
 
     // 첫 번째 약관 페이지로 이동 + 쿼리스트링으로 시퀀스 정보 전달
-    router.push(`/credit/consent/${ids[0]}?bulk=1&ids=${idsParam}&idx=0`);
+    router.replace(`/credit/consent/${ids[0]}?bulk=1&ids=${idsParam}&idx=0`);
   };
 
   // 개별 토글
@@ -118,7 +119,12 @@ export default function ConsentAgree({
 
   return (
     <>
-      <AppHeader title={title} show={true} showHamburger={true} />
+      <AppHeader
+        title={title}
+        show={true}
+        showHamburger={true}
+        onBackClick={onBackClick}
+      />
 
       <div className="flex-1 px-8 pt-16 pb-10 text-left">
         {/* 전체 동의 */}

--- a/src/app/[locale]/credit/consent/page.jsx
+++ b/src/app/[locale]/credit/consent/page.jsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useRouter } from "next/navigation";
 import ConsentAgree from "./components/ConsentAgree";
 
 export default function ConsentPage() {
@@ -19,7 +20,18 @@ export default function ConsentPage() {
     { id: 3, label: "거래내역 기반 신용평가 모델 활용 동의서", required: true },
   ];
 
+  const router = useRouter();
+
+  const handleBack = () => {
+    router.push("/credit/first");
+  };
+
   return (
-    <ConsentAgree title="약관 동의" consents={consents} nextPath={nextPath} />
+    <ConsentAgree
+      title="약관 동의"
+      consents={consents}
+      nextPath={nextPath}
+      onBackClick={handleBack}
+    />
   );
 }

--- a/src/app/[locale]/credit/first/page.jsx
+++ b/src/app/[locale]/credit/first/page.jsx
@@ -1,14 +1,28 @@
 "use client";
 import AppHeader from "@/src/common/AppHeader/AppHeader";
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import Emoji from "../components/Emoji";
 import BottomSheet from "@/src/common/UI/BottomSheet/BottomSheet";
 import { credittoApi } from "@/src/app/api/axios";
+import { useDispatch } from "react-redux";
+import { setConsentChecked } from "@/src/store/features/consent/consentSlice";
 
 export default function CreditFirst() {
   const router = useRouter();
   const [open, setOpen] = useState(false);
+  const dispatch = useDispatch();
+
+  useEffect(() => {
+    // 약관 ID 리스트 아이디 초기화
+    const consentIds = [1, 2, 3];
+
+    // 각 약관의 체크 상태를 false로 초기화
+    consentIds.forEach((id) => {
+      dispatch(setConsentChecked({ id: String(id), checked: false }));
+    });
+  }, [dispatch]);
+
   return (
     <main className="h-dvh flex justify-center items-center bg-[#e5e5e5]">
       <div className="w-full max-w-[440px] min-h-dvh mx-auto justify-start flex flex-col bg-white">
@@ -17,6 +31,7 @@ export default function CreditFirst() {
           showHamburger={false}
           showBack={true}
           show={true}
+          onBackClick={() => router.replace("/main")} // 메인페이지로 이동하는 건 replace로
         />
         <div className="mt-8 text-2xl font-bold text-left ml-5 h-20">
           <span className="text-[#0C72BA] font-bold text-[26px]">신용평가</span>{" "}
@@ -52,20 +67,29 @@ export default function CreditFirst() {
                   return;
                 }
 
-                const res = await credittoApi.get(`/api/credit-score/${userId}`, {
-                  headers: {
-                    Authorization: `Bearer ${accessToken}`,
-                  },
-                });
+                const res = await credittoApi.get(
+                  `/api/credit-score/${userId}`,
+                  {
+                    headers: {
+                      Authorization: `Bearer ${accessToken}`,
+                    },
+                  }
+                );
 
                 // 저장: 전체 응답과 점수 값 별도 보관
                 sessionStorage.setItem("creditScore", JSON.stringify(res.data));
                 if (res.data?.credit_score !== undefined) {
-                  sessionStorage.setItem("creditScoreValue", String(res.data.credit_score));
+                  sessionStorage.setItem(
+                    "creditScoreValue",
+                    String(res.data.credit_score)
+                  );
                 }
                 // 이력 정보도 저장 (변화율 표시용)
                 if (res.data?.history) {
-                  sessionStorage.setItem("creditScoreHistory", JSON.stringify(res.data.history));
+                  sessionStorage.setItem(
+                    "creditScoreHistory",
+                    JSON.stringify(res.data.history)
+                  );
                 }
 
                 router.push("/main");

--- a/src/app/[locale]/send/consent/[id]/page.jsx
+++ b/src/app/[locale]/send/consent/[id]/page.jsx
@@ -2,15 +2,16 @@
 
 import { Button } from "@/components/ui/button";
 import { credittoApi } from "@/src/app/api/axios";
-import { CheckCircle2, X } from "lucide-react";
+import { CheckCircle2 } from "lucide-react";
 import { useParams, useSearchParams, useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
 import { setConsentChecked } from "@/src/store/features/consent/consentSlice";
 import { useDispatch } from "react-redux";
+import BottomSheet from "@/src/common/UI/BottomSheet/BottomSheet";
 
 export default function ConsentDetailPage() {
-  const { id } = useParams(); // 동의서 ID (string)
-  const searchParams = useSearchParams();
+  const { id } = useParams(); // 동의서 ID
+  const searchParam = useSearchParams();
   const router = useRouter();
   const dispatch = useDispatch();
 
@@ -23,32 +24,7 @@ export default function ConsentDetailPage() {
   });
 
   const [scrolledToBottom, setScrolledToBottom] = useState(false);
-  const [status, setStatus] = useState("");
-
-  const agreeConsent = async () => {
-    try {
-      const accessToken = sessionStorage.getItem("accessToken");
-
-      const res = await credittoApi.post("/api/consents/agree", {
-        params: {
-          consentCode: term.consentcode,
-        },
-        headers: {
-          Authorization: `Bearer ${accessToken}`,
-        },
-      });
-
-      const { code, message, data } = res.data;
-      if (code === 201 && data.consentStatus === "AGREE") {
-        console.log(message);
-        setStatus(data.consentStatus); // 동의서 상태를 "AGREE"로 업데이트
-
-        return true;
-      }
-    } catch (error) {
-      console.error("특정 동의서 실패: ", error);
-    }
-  };
+  const [isOpen, setIsOpen] = useState(true);
 
   const handleScroll = (e) => {
     const target = e.currentTarget;
@@ -58,16 +34,30 @@ export default function ConsentDetailPage() {
     setScrolledToBottom(isBottom);
   };
 
+  // 닫기 버튼 클릭 시 bulk가 현재 1이면 약관 동의 페이지로 이동
+  const handleClose = () => {
+    setIsOpen(false);
+    // 애니메이션
+    setTimeout(() => {
+      const isBulk = searchParam.get("bulk") === "1";
+      if (isBulk) {
+        // bulk 모드에서는 리스트로 보내는 편이 UX 좋음
+        router.replace("/send/consent");
+      } else {
+        router.back();
+      }
+    }, 300);
+  };
+
   // 동의 완료 버튼
   const handleAgree = async () => {
     // 동의 성공 시에만 Redux에 저장 후 네비게이션 처리
     const currentId = String(id);
-    dispatch(setConsentChecked({ id: currentId, checked: true }));
+    const isBulk = searchParam.get("bulk") === "1";
+    const idsParam = searchParam.get("ids");
+    const idxParam = searchParam.get("idx");
 
-    // bulk 모드인지 확인
-    const isBulk = searchParams.get("bulk") === "1";
-    const idsParam = searchParams.get("ids");
-    const idxParam = searchParams.get("idx");
+    dispatch(setConsentChecked({ id: currentId, checked: true }));
 
     if (isBulk && idsParam) {
       const ids = idsParam.split(",").filter(Boolean);
@@ -81,8 +71,8 @@ export default function ConsentDetailPage() {
           `/send/consent/${nextId}?bulk=1&ids=${idsParam}&idx=${nextIndex}`
         );
       } else {
-        // 마지막 동의서까지 완료 → 동의 리스트 페이지로 이동
-        router.push("/send/consent");
+        // 마지막 동의서까지 완료 - 동의 리스트 페이지로 이동
+        router.replace("/send/consent");
       }
     } else {
       // 이전 페이지로 돌아가기
@@ -116,68 +106,39 @@ export default function ConsentDetailPage() {
   }, [id]);
 
   return (
-    <div className="fixed inset-0 z-50 flex items-end justify-center bg-black/50 backdrop-blur-sm sm:items-center">
-      <div className="relative flex h-[66vh] w-full max-w-2xl flex-col animate-in slide-in-from-bottom-10 rounded-t-2xl bg-card shadow-2xl sm:rounded-2xl">
-        {/* 동의서 상단바 */}
-        <div className="sticky top-0 z-10 flex items-center justify-between bg-card px-6 py-4">
-          <div className="flex items-center justify-center gap-2">
-            {/* 동의서 제목 */}
-            <h2 className="text-lg font-semibold text-black">
-              {term.consentTitle}
-            </h2>
-
-            {/* 필수 태그 */}
-            <span className="mt-1 inline-block rounded-full bg-[#E5E6EB] px-2 py-1 text-xs font-medium">
-              필수
-            </span>
-          </div>
-
-          {/* 닫기 버튼 */}
-          <button
-            onClick={() => {
-              const isBulk = searchParams.get("bulk") === "1";
-              if (isBulk) {
-                // bulk 모드에서는 리스트로 보내는 편이 UX 좋음
-                router.push("/send/consent");
-              } else {
-                router.back();
-              }
-            }}
-            className="rounded-lg p-2 text-muted-foreground transition-colors hover:bg-secondary hover:text-foreground"
-          >
-            <X className="h-5 w-5" />
-          </button>
-        </div>
-
-        {/* 동의서 내용 */}
-        <div
-          onScroll={handleScroll}
-          className="flex-1 overflow-y-auto px-6 py-4" // 남은 높이를 다 쓰고 넘치면 스크롤
-        >
-          <div className="whitespace-pre-wrap text-sm leading-[3.0] text-left text-black">
-            {term.consentDesc}
-          </div>
-        </div>
-
-        {/* 스크롤 바 */}
-        {!scrolledToBottom && (
-          <div className="pointer-events-none absolute bottom-24 left-0 right-0 h-20 bg-gradient-to-t from-card to-transparent" />
-        )}
-
-        {/* 고정 하단 버튼 */}
-        <div className="sticky bottom-0 bg-[card] px-6 py-4">
-          <Button
-            onClick={handleAgree}
-            className="w-full rounded-xl py-6 text-base font-semibold bg-[#1A3668]"
-            size="lg"
-          >
-            <span className="flex items-center gap-2">
-              <CheckCircle2 className="h-5 w-5" />
-              동의 완료
-            </span>
-          </Button>
+    <BottomSheet
+      open={isOpen}
+      onOpenChange={handleClose}
+      title={term.consentTitle}
+    >
+      <div
+        onScroll={handleScroll}
+        className="flex-1 overflow-y-auto px-6 py-4" // 남은 높이를 다 쓰고 넘치면 스크롤
+      >
+        <div className="whitespace-pre-wrap text-sm leading-[3.0] text-left text-black">
+          {term.consentDesc}
         </div>
       </div>
-    </div>
+
+      {/* 스크롤 바 */}
+      {!scrolledToBottom && (
+        <div className="pointer-events-none absolute bottom-24 left-0 right-0 h-20 bg-gradient-to-t from-white to-transparent" />
+      )}
+
+      {/* 고정 하단 버튼 */}
+      <div className="sticky bottom-0 bg-white px-6 py-4">
+        <Button
+          onClick={handleAgree}
+          disabled={!scrolledToBottom}
+          className="w-full rounded-xl py-6 text-base font-semibold bg-[#1A3668] disabled:bg-[#E5E6EB]"
+          size="lg"
+        >
+          <span className="flex items-center gap-2">
+            <CheckCircle2 className="h-5 w-5" />
+            동의 완료
+          </span>
+        </Button>
+      </div>
+    </BottomSheet>
   );
 }

--- a/src/app/[locale]/send/consent/components/ConsentAgree.jsx
+++ b/src/app/[locale]/send/consent/components/ConsentAgree.jsx
@@ -10,6 +10,7 @@ import { clearModeData } from "@/src/store/features/send/sendModeSlice";
 export default function ConsentAgree({
   title = "약관 동의",
   consents = [], // 약관 동의서 리스트
+  onBackClick,
 }) {
   const router = useRouter();
   const dispatch = useDispatch();
@@ -55,7 +56,7 @@ export default function ConsentAgree({
     const idsParam = ids.join(",");
 
     // 첫 번째 약관 페이지로 이동 + 쿼리스트링으로 시퀀스 정보 전달
-    router.push(`/send/consent/${ids[0]}?bulk=1&ids=${idsParam}&idx=0`);
+    router.replace(`/send/consent/${ids[0]}?bulk=1&ids=${idsParam}&idx=0`);
   };
 
   // 개별 토글
@@ -125,7 +126,12 @@ export default function ConsentAgree({
 
   return (
     <>
-      <AppHeader title={title} show={true} showHamburger={true} />
+      <AppHeader
+        title={title}
+        show={true}
+        showHamburger={true}
+        onBackClick={onBackClick}
+      />
 
       <div className="flex-1 px-8 pt-16 pb-10 text-left">
         {/* 전체 동의 */}

--- a/src/app/[locale]/send/consent/page.jsx
+++ b/src/app/[locale]/send/consent/page.jsx
@@ -66,5 +66,16 @@ export default function ConsentPage() {
     { id: 6, label: "해외송금 제한 국가 관련 확인 동의서", required: true },
   ];
 
-  return <ConsentAgree title="약관 동의" consents={consents} />;
+  // 송금 메인페이지로 이동
+  const handleBack = () => {
+    router.push("/send");
+  };
+
+  return (
+    <ConsentAgree
+      title="약관 동의"
+      consents={consents}
+      onBackClick={handleBack}
+    />
+  );
 }

--- a/src/app/[locale]/send/page.jsx
+++ b/src/app/[locale]/send/page.jsx
@@ -3,11 +3,34 @@
 import CardCarousel from "./components/CardCarousel";
 import AppHeader from "@/src/common/AppHeader/AppHeader";
 import { useRouter } from "next/navigation";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useTranslations } from "next-intl";
+import { useDispatch } from "react-redux";
+import { setConsentChecked } from "@/src/store/features/consent/consentSlice";
+import { clearModeData } from "@/src/store/features/send/sendModeSlice";
 
 export default function SendMainPage() {
   const t = useTranslations("send.common");
+  const dispatch = useDispatch();
+
+  useEffect(() => {
+    // 약관 ID 리스트 아이디 초기화
+    const consentIds = [4, 5, 6];
+
+    // 각 약관의 체크 상태를 false로 초기화
+    consentIds.forEach((id) => {
+      dispatch(
+        setConsentChecked({
+          id: String(id),
+          checked: false, // 체크 해제
+        })
+      );
+    });
+
+    // 송금 모드 관련 Redux 상태 초기화 (예: sendModeSlice)
+    dispatch(clearModeData());
+  }, [dispatch]); // 컴포넌트 최초 렌더링 시 1회 실행
+
   return (
     <div className="min-h-screen bg-white flex flex-col">
       {/* 헤더 */}

--- a/src/app/[locale]/send/page.jsx
+++ b/src/app/[locale]/send/page.jsx
@@ -3,7 +3,7 @@
 import CardCarousel from "./components/CardCarousel";
 import AppHeader from "@/src/common/AppHeader/AppHeader";
 import { useRouter } from "next/navigation";
-import { useEffect, useState } from "react";
+import { useEffect } from "react";
 import { useTranslations } from "next-intl";
 import { useDispatch } from "react-redux";
 import { setConsentChecked } from "@/src/store/features/consent/consentSlice";
@@ -12,6 +12,7 @@ import { clearModeData } from "@/src/store/features/send/sendModeSlice";
 export default function SendMainPage() {
   const t = useTranslations("send.common");
   const dispatch = useDispatch();
+  const router = useRouter();
 
   useEffect(() => {
     // 약관 ID 리스트 아이디 초기화
@@ -39,6 +40,7 @@ export default function SendMainPage() {
         show={true}
         showHamburger={false}
         showBack={true}
+        onBackClick={() => router.replace("/main")} // 메인페이지로 이동하는 건 replace로
       />
 
       <div className="flex-1 flex flex-col px-5 relative">

--- a/src/common/AppHeader/AppHeader.jsx
+++ b/src/common/AppHeader/AppHeader.jsx
@@ -1,6 +1,7 @@
 "use client";
 import Hambuger from "@/src/app/[locale]/main/components/Hambuger";
 import { ChevronLeft } from "lucide-react";
+import { useRouter } from "next/navigation";
 import React from "react";
 
 export default function AppHeader({
@@ -8,13 +9,23 @@ export default function AppHeader({
   showBack = true,
   show = true,
   showHamburger = true,
+  onBackClick, // 특정 뒤로가기로 이동하고 싶을 때 실행하는 함수
 
   // 수정 관련
   showEdit = false,
   edit,
   handleEdit,
 }) {
+  const router = useRouter();
   if (!show) return null;
+
+  const handleBack = () => {
+    if (onBackClick) {
+      onBackClick();
+    } else {
+      router.back();
+    }
+  };
 
   return (
     <header className="w-full flex items-center justify-between px-6 py-3 bg-white ">
@@ -22,9 +33,7 @@ export default function AppHeader({
         {showBack && (
           <ChevronLeft
             className="w-15 h-15 cursor-pointer"
-            onClick={() => {
-              history.back();
-            }}
+            onClick={handleBack}
           />
         )}
       </div>

--- a/src/common/UI/BottomSheet/BottomSheet.js
+++ b/src/common/UI/BottomSheet/BottomSheet.js
@@ -1,12 +1,15 @@
 "use client";
 
-import { useId } from "react";
 import * as Dialog from "@radix-ui/react-dialog";
 import { AnimatePresence, motion } from "framer-motion";
 
-export default function BottomSheet({ open, onOpenChange, title, trigger, children }) {
-  const labelId = useId();
-
+export default function BottomSheet({
+  open,
+  onOpenChange,
+  title,
+  trigger,
+  children,
+}) {
   return (
     <Dialog.Root open={open} onOpenChange={onOpenChange}>
       {/* 열기 버튼 */}
@@ -18,31 +21,35 @@ export default function BottomSheet({ open, onOpenChange, title, trigger, childr
             {/* 오버레이 */}
             <Dialog.Overlay asChild>
               <motion.div
-                className="fixed inset-0 bg-black/40 z-40 "
+                className="fixed inset-0 bg-black/40 z-40"
                 initial={{ opacity: 0 }}
                 animate={{ opacity: 1 }}
                 exit={{ opacity: 0 }}
               />
             </Dialog.Overlay>
 
+            {/* 접근성용 숨겨진 제목 (필수) */}
+            <Dialog.Title className="sr-only">
+              {title || "Bottom sheet"}
+            </Dialog.Title>
+
             {/* 바텀 시트 본체 */}
-            <Dialog.Content asChild aria-labelledby={labelId}>
+            <Dialog.Content asChild>
               <motion.div
-                className="fixed inset-x-0 bottom-0  z-50 max-h-[80dvh] rounded-t-2xl bg-white
-                           shadow-[0_-8px_30px_rgba(0,0,0,0.2)] p-5 flex flex-col "
+                className="fixed inset-x-0 bottom-0 z-50 max-h-[80dvh] rounded-t-2xl bg-white
+                           shadow-[0_-8px_30px_rgba(0,0,0,0.2)] p-5 flex flex-col"
                 initial={{ y: "100%" }}
                 animate={{ y: 0 }}
                 exit={{ y: "100%" }}
                 transition={{ type: "spring", stiffness: 400, damping: 32 }}
               >
-                {/* 헤더 */}
+                {/* 헤더 (눈에 보이는 부분, 꼭 Title일 필요 X) */}
                 <div className="mb-3 flex items-center justify-between">
-                  <Dialog.Title
-                    id={labelId}
-                    className="text-base font-semibold text-gray-900"
-                  >
-                    {title}
-                  </Dialog.Title>
+                  {title && (
+                    <h2 className="text-base font-semibold text-gray-900">
+                      {title}
+                    </h2>
+                  )}
 
                   <Dialog.Close asChild>
                     <button


### PR DESCRIPTION
## 🗞️ 연관된 이슈

### 🔥 이슈번호
- *Resolved* : #99 

## ✅ 작업 내용
- 약관 동의 내용 페이지에서 약관 페이지(ConsentPage)로 가서 뒤로갔을 때 송금은 "/send", 신용도는 "/credit/first"로 이동할 수 있도록 구현
- 그렇게 되면 "/send"와 "/credit/first"에서 뒤로 갔을 때 약관 페이지로 이동하는 오류가 발생해 route.replace를 사용하면 무조건 "/main" 페이지로 이동하도록 구현

### 📸 스크린샷 (선택)

## 체크리스트 ✅
- [x] 코드가 정상적으로 컴파일되나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [ ] 테스트 코드를 작성하셨나요?

## 기타
