### PR TITLE
refactor : 계좌 페이지 라우터링 구조 개선 / #114

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -367,7 +367,7 @@
     "success": {
       "title": "Account created successfully!",
       "description": "Now, start your life with Creditto.",
-      "toMain": "To the main screen"
+      "toMyAccount": "Check my account"
     },
     "import": {
       "noAccessToken": "Access Token is missing.",

--- a/messages/jp.json
+++ b/messages/jp.json
@@ -367,7 +367,7 @@
     "success": {
       "title": "口座が開設されました！",
       "description": "さあ、Credittoのある生活を始めましょう。",
-      "toMain": "メイン画面へ"
+      "toMyAccount": "マイアカウントを確認する"
     },
     "import": {
       "noAccessToken": "アクセストークンがありません。",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -367,7 +367,7 @@
     "success": {
       "title": "계좌가 생성되었어요 !",
       "description": "이제 Creditto의 생활을 시작해 보세요",
-      "toMain": "메인 화면으로"
+      "toMyAccount": "내 계좌 확인하기"
     },
     "import": {
       "noAccessToken": "Access Token이 없습니다.",

--- a/src/app/[locale]/account/connection/page.jsx
+++ b/src/app/[locale]/account/connection/page.jsx
@@ -11,7 +11,7 @@ export default function AccountConnectionPage() {
   const t = useTranslations("account.connection");
   const router = useRouter();
   // Redux 스토어에서 계좌 목록을 가져옵니다.
-  const name = sessionStorage.getItem("userName") // TODO: get user name from store
+  const name = sessionStorage.getItem("userName"); // TODO: get user name from store
 
   useEffect(() => {
     const accountsString = sessionStorage.getItem("accounts");

--- a/src/app/[locale]/account/create/success/page.jsx
+++ b/src/app/[locale]/account/create/success/page.jsx
@@ -40,9 +40,9 @@ export default function AccountSuccessPage() {
 
         <footer>
           <BottomBar
-            label={t("toMain")}
+            label={t("toMyAccount")}
             onClick={() => {
-              router.push("/account/my_account?refresh=true");
+              router.replace("/account/my_account?refresh=true");
             }}
             isActive={true}
           />

--- a/src/app/[locale]/account/my_account/page.jsx
+++ b/src/app/[locale]/account/my_account/page.jsx
@@ -19,6 +19,7 @@ export default function MyAccountPage() {
         show={true}
         showBack={true}
         showHamburger={false}
+        onBackClick={() => router.replace("/main")}
       />
 
       {/* 콘텐츠 영역 */}

--- a/src/app/[locale]/auth/info/page.jsx
+++ b/src/app/[locale]/auth/info/page.jsx
@@ -15,6 +15,12 @@ import { countryCodes } from "../../constants/countryCode";
 import { startSettingMode as settingModeAction } from "@/src/store/features/simplepw/simplepwSlice";
 import { useTranslations } from "next-intl";
 
+// API 에러코드를 상수로 선언
+export const API_ERROR_CODES = {
+  DUPLICATE_PHONE_NUMBER: 40010,
+  INVALID_NAME_FORMAT: 400,
+};
+
 export default function InfoInputPage() {
   const t = useTranslations("auth.info");
 
@@ -139,7 +145,7 @@ export default function InfoInputPage() {
         );
 
         router.push("/auth/pw");
-      } else if (res.code === 40010) {
+      } else if (res.code === DUPLICATE_PHONE_NUMBER) {
         // 중복된 전화번호가 있을 때 전화번호 필드에 에러 표시
         setFieldErrors((prev) => ({
           ...prev,

--- a/src/app/[locale]/auth/info/page.jsx
+++ b/src/app/[locale]/auth/info/page.jsx
@@ -139,7 +139,7 @@ export default function InfoInputPage() {
         );
 
         router.push("/auth/pw");
-      } else if (res.code === 409) {
+      } else if (res.code === 40010) {
         // 중복된 전화번호가 있을 때 전화번호 필드에 에러 표시
         setFieldErrors((prev) => ({
           ...prev,


### PR DESCRIPTION
## 🗞️ 연관된 이슈

### 🔥 이슈번호
- *Resolved* : #114 

## ✅ 작업 내용
- 계좌 생성 완료 후 내 계좌 페이지로 가야하는 버튼의 텍스트 수정
- 내 계좌 페이지에서 뒤로가기 눌렀을 때 메인페이지로 이동

### 📸 스크린샷 (선택)

## 체크리스트 ✅
- [x] 코드가 정상적으로 컴파일되나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [ ] 테스트 코드를 작성하셨나요?

## 기타
