### PR TITLE
fix : 성공 페이지 신용도 점수 표기 오류 수정 / #116

### DIFF
--- a/src/app/[locale]/account/connection/page.jsx
+++ b/src/app/[locale]/account/connection/page.jsx
@@ -42,7 +42,7 @@ export default function AccountConnectionPage() {
         </div>
         <div>{t("description", { name })}</div>
       </div>
-      <div className="w-full  min-h-[440px] justify-center items-center flex">
+      <div className="w-full min-h-[440px] justify-center items-center flex flex-1">
         <Image
           src="/icon/woori.png"
           alt={t("wooriLogo")}
@@ -52,7 +52,7 @@ export default function AccountConnectionPage() {
       </div>
       <footer>
         <BottomBar
-          label={t("complete")}
+          label="다음"
           onClick={() => router.push("/account/my_account")}
           isActive={true}
         />

--- a/src/app/[locale]/send/components/CardCarousel.jsx
+++ b/src/app/[locale]/send/components/CardCarousel.jsx
@@ -53,7 +53,7 @@ export default function CardCarousel() {
         const { code, data } = res.data;
 
         if (code === 200) {
-          if (data.accountcount !== 0) {
+          if (data.accountcount === 0) {
             alert("연동된 계좌가 없습니다");
             router.replace("/");
           }

--- a/src/app/[locale]/send/components/CardCarousel.jsx
+++ b/src/app/[locale]/send/components/CardCarousel.jsx
@@ -3,9 +3,8 @@
 import clsx from "clsx";
 import { motion } from "framer-motion";
 import { Globe, Repeat } from "lucide-react";
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 import { useRouter } from "next/navigation";
-import { useSelector } from "react-redux";
 import "react-responsive-carousel/lib/styles/carousel.min.css";
 import SendBtn from "../regular/components/SendBtn";
 import { credittoApi } from "@/src/app/api/axios";
@@ -34,9 +33,13 @@ export default function CardCarousel() {
   const router = useRouter();
   const [activeIndex, setActiveIndex] = useState(0);
   const [isFlipped, setIsFlipped] = useState(false);
+  const didFetch = useRef(false); // useEffect()가 2번 실행되는 걸 방지하기 위해 선언
 
+  // 연동된 계좌가 있으면 송금 기능 사용 가능
   useEffect(() => {
-    // 계좌 잔액 합산 조회 by UserId
+    if (didFetch.current) return; // 두 번째 실행 차단
+    didFetch.current = true;
+
     const fetchAccountBalance = async () => {
       try {
         const accessToken = sessionStorage.getItem("accessToken");
@@ -48,13 +51,12 @@ export default function CardCarousel() {
         });
 
         const { code, data } = res.data;
+
         if (code === 200) {
-          // 송금 화면 이용 가능
-          console.log("연동된 계좌 있음");
-        } else {
-          // 메인페이지로 이동
-          alert("연동된 계좌가 없습니다");
-          router.replace("/");
+          if (data.accountcount !== 0) {
+            alert("연동된 계좌가 없습니다");
+            router.replace("/");
+          }
         }
       } catch (error) {
         console.error("계좌 잔액 합산 조회 by UserId 오류 발생: ", error);

--- a/src/app/[locale]/send/regular/complete/page.jsx
+++ b/src/app/[locale]/send/regular/complete/page.jsx
@@ -86,7 +86,7 @@ export default function CompletePage() {
         const userId = sessionStorage.getItem("userId");
 
         if (!accessToken || !userId) return;
-        if (!hasCreditHistory || creditScore == null) return;
+        if (!hasCreditHistory || creditScore === null) return;
 
         const res = await credittoApi.post(
           `/api/credit-score/prediction`,

--- a/src/app/[locale]/send/regular/complete/page.jsx
+++ b/src/app/[locale]/send/regular/complete/page.jsx
@@ -10,12 +10,20 @@ import AppHeader from "@/src/common/AppHeader/AppHeader";
 import { useTranslations } from "next-intl";
 import { useEffect, useState } from "react";
 import { credittoApi } from "@/src/app/api/axios";
+import { useSelector } from "react-redux";
 
 export default function CompletePage() {
   const router = useRouter();
   const t = useTranslations("send");
 
-  const [creditScore, setCreditScore] = useState(0); // 신용점수
+  const [creditScore, setCreditScore] = useState(null); // 최신 신용 점수
+  const [hasCreditHistory, setHasCreditHistory] = useState(false); // 신용 점수 조회 이력 여부
+
+  const [sixScore, setSixScore] = useState(null); // 6개월 예측
+  const [twelveScore, setTwelveScore] = useState(null); // 12개월 예측
+  const [eighteenScore, setEighteenScore] = useState(null); // 18개월 예측
+
+  const monthly_amount = useSelector((state) => state.send.sendAmount); // 월 정기 송금액
 
   // 브라우저 뒤로가기
   useEffect(() => {
@@ -31,7 +39,6 @@ export default function CompletePage() {
   }, [router]);
 
   useEffect(() => {
-    // 최신 신용점수 조회
     const fetchRecentScore = async () => {
       try {
         const accessToken = sessionStorage.getItem("accessToken");
@@ -39,12 +46,54 @@ export default function CompletePage() {
 
         if (!accessToken || !userId) {
           console.error("인증 정보가 없어 신용점수를 조회할 수 없습니다.");
+          setHasCreditHistory(false);
           return;
         }
 
+        const res = await credittoApi.get(`/api/credit-score/${userId}`, {
+          headers: {
+            Authorization: `Bearer ${accessToken}`,
+          },
+        });
+
+        // 응답 구조: { credit_score: 773 }
+        const score = res.data?.credit_score;
+
+        if (score != null) {
+          setHasCreditHistory(true); // 조회 이력 있음
+          setCreditScore(score); // 최신 신용 점수 저장
+          console.log("신용 점수 응답: ", score);
+        } else {
+          // score가 없으면 조회 이력 없다고 간주
+          setHasCreditHistory(false);
+          setCreditScore(null);
+        }
+      } catch (error) {
+        console.error("최신 신용점수 조회 중 오류 발생: ", error);
+        setHasCreditHistory(false);
+        setCreditScore(null);
+      }
+    };
+
+    fetchRecentScore();
+  }, []);
+
+  // 예측 신용도 점수
+  useEffect(() => {
+    const predictCreditScore = async () => {
+      try {
+        const accessToken = sessionStorage.getItem("accessToken");
+        const userId = sessionStorage.getItem("userId");
+
+        if (!accessToken || !userId) return;
+        if (!hasCreditHistory || creditScore == null) return;
+
         const res = await credittoApi.post(
-          `/api/credit-score/${userId}`,
-          null, // POST 요청 본문이 없는 경우 null로 전달
+          `/api/credit-score/prediction`,
+          {
+            user_id: userId,
+            monthly_amount: monthly_amount,
+          },
           {
             headers: {
               Authorization: `Bearer ${accessToken}`,
@@ -52,18 +101,25 @@ export default function CompletePage() {
           }
         );
 
-        const data = res.data;
+        // 응답 그대로 사용 (code, data 래퍼 없음)
+        const prediction = res.data;
 
-        if (data) {
-          setCreditScore(data.credit_score); // 최신 신용점수 업데이트
-        }
+        if (!prediction) return;
+
+        console.log("예측 신용 점수 조회 성공: ", prediction);
+
+        setSixScore(prediction.after_6m?.score ?? null);
+        setTwelveScore(prediction.after_12m?.score ?? null);
+        setEighteenScore(prediction.after_18m?.score ?? null);
       } catch (error) {
-        console.error("최신 신용점수 조회 중 오류 발생: ", error);
+        console.error("예측 신용 점수 조회 중 오류 발생: ", error);
       }
     };
 
-    fetchRecentScore();
-  }, []);
+    if (hasCreditHistory) {
+      predictCreditScore();
+    }
+  }, [hasCreditHistory, creditScore, monthly_amount]);
 
   return (
     <div className="min-h-dvh flex flex-col bg-white">
@@ -92,27 +148,34 @@ export default function CompletePage() {
             />
           </center>
 
-          <p className="text-left text-xl font-bold text-black">
-            {t("components.complete.currentScore")}{" "}
-            <span className="font-bold text-[#1A3668]">{creditScore}</span>
-            {t("components.creditPointBanner.point")}
-          </p>
+          {/* 신용 점수 조회 상태에 따른 UI 표기 분기 */}
+          {!hasCreditHistory ? (
+            // 조회 이력 없음
+            <p className="text-left text-xl font-bold text-black">
+              아직 평가 이력이 없어요
+            </p>
+          ) : (
+            // 조회 이력 O → 현재 점수 + 예측 점수
+            <div>
+              <p className="text-left text-xl font-bold text-black">
+                {t("components.complete.currentScore")}{" "}
+                <span className="font-bold text-[#1A3668]">{creditScore}</span>
+                {t("components.creditPointBanner.point")}
+              </p>
 
-          {/* 신용도 점수 배너 */}
-          <section className="flex flex-col gap-4">
-            <CreditScoreBanner
-              label={t("components.complete.months12")}
-              point="767"
-            />
-            <CreditScoreBanner
-              label={t("components.complete.months18")}
-              point="777"
-            />
-            <CreditScoreBanner
-              label={t("components.complete.months24")}
-              point="787"
-            />
-          </section>
+              <section className="flex flex-col gap-4">
+                <CreditScoreBanner label="6개월 정기 송금시" point={sixScore} />
+                <CreditScoreBanner
+                  label="12개월 정기 송금시"
+                  point={twelveScore}
+                />
+                <CreditScoreBanner
+                  label="18개월 정기 송금시"
+                  point={eighteenScore}
+                />
+              </section>
+            </div>
+          )}
 
           {/* 약관 동의 */}
           <Term />

--- a/src/lib/constants/countryCode.js
+++ b/src/lib/constants/countryCode.js
@@ -11,6 +11,7 @@ export const countryCodes = [
   { name: "아랍에미리트", countryCode: "ARE" },
   { name: "영국", countryCode: "GBR" },
   { name: "말레이시아", countryCode: "MYS" },
+  { name: "태국", countryCode: "THA" },
   { name: "인도네시아", countryCode: "IDN" },
   { name: "がはこと", countryCode: "UTO" },
 ];


### PR DESCRIPTION
## 🗞️ 연관된 이슈

### 🔥 이슈번호
- *Resolved* : #116 

## ✅ 작업 내용
- 현재 신용도 점수 불러와서 예측 신용도 점수 조회하기
- 계좌 수(accountcount)가 0이면 연동된 계좌가 없다고 수정
- 연결 계좌 페이지에 완료에서 다음으로 텍스트 수정

### 📸 스크린샷 (선택)

## 체크리스트 ✅
- [x] 코드가 정상적으로 컴파일되나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [ ] 테스트 코드를 작성하셨나요?

## 기타
